### PR TITLE
[INIT] HCP Vault 기반 Secret Manager 적용

### DIFF
--- a/doong2-bootstrap/src/main/kotlin/wyship/doong2/bootstrap/secret/SecretLoader.kt
+++ b/doong2-bootstrap/src/main/kotlin/wyship/doong2/bootstrap/secret/SecretLoader.kt
@@ -1,0 +1,5 @@
+package wyship.doong2.bootstrap.secret
+
+fun interface SecretLoader {
+    fun load(): Map<String, String>
+}

--- a/doong2-bootstrap/src/main/kotlin/wyship/doong2/bootstrap/secret/SecretLoaderFactory.kt
+++ b/doong2-bootstrap/src/main/kotlin/wyship/doong2/bootstrap/secret/SecretLoaderFactory.kt
@@ -1,0 +1,13 @@
+package wyship.doong2.bootstrap.secret
+
+import org.springframework.core.env.ConfigurableEnvironment
+import wyship.doong2.bootstrap.secret.hcp.HcpVaultSecretLoader
+
+object SecretLoaderFactory {
+    fun create(env: ConfigurableEnvironment): SecretLoader {
+        return when (env.getProperty("vault.provider") ?: "hcp") {
+            "hcp" -> HcpVaultSecretLoader(env)
+            else -> error("잘못된 Secret Manager")
+        }
+    }
+}

--- a/doong2-bootstrap/src/main/kotlin/wyship/doong2/bootstrap/secret/SecretPostProcessor.kt
+++ b/doong2-bootstrap/src/main/kotlin/wyship/doong2/bootstrap/secret/SecretPostProcessor.kt
@@ -1,0 +1,21 @@
+package wyship.doong2.bootstrap.secret
+
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.env.EnvironmentPostProcessor
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.MapPropertySource
+
+class SecretPostProcessor : EnvironmentPostProcessor {
+
+    override fun postProcessEnvironment(env: ConfigurableEnvironment, application: SpringApplication?) {
+        val loader = SecretLoaderFactory.create(env)
+        val secrets = loader.load()
+
+        val propertySource = MapPropertySource(PROPERTY_SOURCE_NAME, secrets)
+        env.propertySources.addFirst(propertySource)
+    }
+
+    companion object {
+        private const val PROPERTY_SOURCE_NAME = "envSecret"
+    }
+}

--- a/doong2-bootstrap/src/main/kotlin/wyship/doong2/bootstrap/secret/hcp/HcpVaultSecretClient.kt
+++ b/doong2-bootstrap/src/main/kotlin/wyship/doong2/bootstrap/secret/hcp/HcpVaultSecretClient.kt
@@ -1,0 +1,82 @@
+package wyship.doong2.bootstrap.secret.hcp
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestClient
+
+class HcpVaultSecretClient(
+    private val clientId: String,
+    private val clientSecret: String
+) {
+    private val restClient = RestClient.create()
+
+    fun fetchSecrets(orgId: String, projectId: String, appId: String): Map<String, String> {
+        val token = issueAccessToken()
+
+        val response = restClient.get()
+            .uri("$VAULT_BASE_URL/organizations/$orgId/projects/$projectId/apps/$appId$OPEN_SECRETS_PATH")
+            .header(HttpHeaders.AUTHORIZATION, "$BEARER_PREFIX $token")
+            .retrieve()
+            .body(HcpVaultOpenResponse::class.java)
+            ?: error("Vault에서 시크릿 정보를 불러오기 실패")
+
+        return response.secrets
+            .filter { it.staticVersion != null }
+            .associate { it.name to it.staticVersion!!.value }
+    }
+
+    private fun issueAccessToken(): String {
+        val formData = LinkedMultiValueMap<String, String>().apply {
+            add(FIELD_CLIENT_ID, clientId)
+            add(FIELD_CLIENT_SECRET, clientSecret)
+            add(FIELD_GRANT_TYPE, GRANT_TYPE_CLIENT_CREDENTIALS)
+            add(FIELD_AUDIENCE, VAULT_API_AUDIENCE)
+        }
+
+        val tokenResponse = restClient.post()
+            .uri(VAULT_AUTH_URL)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .body(formData)
+            .retrieve()
+            .body(TokenResponse::class.java)
+            ?: error("HCP Vault 액세스 토큰 발급 실패")
+
+        return tokenResponse.accessToken
+    }
+
+    companion object {
+        private const val VAULT_AUTH_URL = "https://auth.idp.hashicorp.com/oauth2/token"
+        private const val VAULT_BASE_URL = "https://api.cloud.hashicorp.com/secrets/2023-11-28"
+        private const val VAULT_API_AUDIENCE = "https://api.hashicorp.cloud"
+        private const val OPEN_SECRETS_PATH = "/secrets:open"
+
+        private const val FIELD_CLIENT_ID = "client_id"
+        private const val FIELD_CLIENT_SECRET = "client_secret"
+        private const val FIELD_GRANT_TYPE = "grant_type"
+        private const val FIELD_AUDIENCE = "audience"
+        private const val GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials"
+        private const val BEARER_PREFIX = "Bearer"
+    }
+}
+
+data class TokenResponse(
+    @JsonProperty("access_token")
+    val accessToken: String
+)
+
+data class HcpVaultOpenResponse(
+    val secrets: List<OpenSecret>
+)
+
+data class OpenSecret(
+    val name: String,
+    @JsonProperty("static_version")
+    val staticVersion: StaticVersion?
+)
+
+data class StaticVersion(
+    val version: Int,
+    val value: String
+)

--- a/doong2-bootstrap/src/main/kotlin/wyship/doong2/bootstrap/secret/hcp/HcpVaultSecretLoader.kt
+++ b/doong2-bootstrap/src/main/kotlin/wyship/doong2/bootstrap/secret/hcp/HcpVaultSecretLoader.kt
@@ -1,0 +1,46 @@
+package wyship.doong2.bootstrap.secret.hcp
+
+import org.springframework.boot.context.properties.bind.Bindable
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.core.env.ConfigurableEnvironment
+import wyship.doong2.bootstrap.secret.SecretLoader
+
+class HcpVaultSecretLoader(
+    private val env: ConfigurableEnvironment
+) : SecretLoader {
+
+    private val profile: String = env.activeProfiles.firstOrNull() ?: DEFAULT_PROFILE
+
+    override fun load(): Map<String, String> {
+        val clientId = getOrThrow(PROP_CLIENT_ID)
+        val clientSecret = getOrThrow(PROP_CLIENT_SECRET)
+        val orgId = getOrThrow(PROP_ORG_ID)
+        val projectId = getOrThrow(PROP_PROJECT_ID)
+        val appId = getAppIdForProfile(profile)
+
+        val client = HcpVaultSecretClient(clientId, clientSecret)
+        return client.fetchSecrets(orgId, projectId, appId)
+    }
+
+    private fun getAppIdForProfile(profile: String): String {
+        val map: Map<String, String> = Binder.get(env)
+            .bind(PROP_APP_ID, Bindable.mapOf(String::class.java, String::class.java))
+            .orElseThrow { error("property '$PROP_APP_ID'이(가) 없음") }
+
+        return map[profile]
+            ?: error("프로필 '$profile'에 해당하는 App ID가 '$PROP_APP_ID'에 설정되어 있지 않음")
+    }
+
+    private fun getOrThrow(key: String): String =
+        env.getProperty(key) ?: error("할당 실패한 property: $key")
+
+    companion object {
+        private const val DEFAULT_PROFILE = "default"
+
+        private const val PROP_CLIENT_ID = "vault.hcp.client-id"
+        private const val PROP_CLIENT_SECRET = "vault.hcp.client-secret"
+        private const val PROP_ORG_ID = "vault.hcp.org-id"
+        private const val PROP_PROJECT_ID = "vault.hcp.project-id"
+        private const val PROP_APP_ID = "vault.hcp.app-id"
+    }
+}

--- a/doong2-bootstrap/src/main/resources/META-INF/spring.factories
+++ b/doong2-bootstrap/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.env.EnvironmentPostProcessor=wyship.doong2.bootstrap.secret.SecretPostProcessor

--- a/doong2-bootstrap/src/main/resources/application-test.yml
+++ b/doong2-bootstrap/src/main/resources/application-test.yml
@@ -1,0 +1,2 @@
+test:
+  value: test-testt

--- a/doong2-bootstrap/src/main/resources/application.yml
+++ b/doong2-bootstrap/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+vault:
+  hcp:
+    client-id: ${HCP_CLIENT_ID}
+    client-secret: ${HCP_CLIENT_SECRET}
+    org-id: ${HCP_ORG_ID}
+    project-id: ${HCP_PROJECT_ID}
+    app-id:
+      default: server-local
+      local: server-local
+      prod: server-prod
+      test: server-test
+
+test:
+  value: ${TEST_VALUE}


### PR DESCRIPTION
## Issue
closed #5 

## Description
HCP Vault Secrets API 기반으로 Secret 로드되도록 작성하였습니닷! 
그냥 간단하게 불러오는 방식으로 구현했다가, 한 달에 최대 10,000번 호출까지 가능하다길래😂
혹시 몰라 추상화하느라 불가피하게 클래스가 많아진 점 양해 부탁입니당
- SecretLoader 인터페이스 작성
- HcpVaultSecretLoader 구현체 생성
- SecretLoaderFactory, SecretPostProcessor 구현
- 프로필에 따라 다른 app-id 로드



관련 정보들도 적어놓을게용
- [시크릿 키 추가 콘솔](https://portal.cloud.hashicorp.com/services/secrets?project_id=9a4856ea-5586-40df-a468-f7defa187be7)
- [Hashicorp 계정 정보](https://www.notion.so/hashicorp-205bee7f59968025a0d8de0784311605?source=copy_link)
- [환경 변수](https://www.notion.so/Github-Secret-Env-Secret-1febee7f599680b6a3a0f14f7cd321ea?source=copy_link)
